### PR TITLE
escape parentheses within inline URLs

### DIFF
--- a/src/plugin/predefined/AnchorPlugin.js
+++ b/src/plugin/predefined/AnchorPlugin.js
@@ -85,6 +85,10 @@ var AnchorPlugin = Plugin.extend({
     if (!href) {
       return true;
     }
+    if (options.inline) {
+      href = href.replace(/\(/g, '%28');
+      href = href.replace(/\)/g, '%29');
+    }
 
     var anchorMap = conversion.context.anchorMap;
     var anchors = conversion.context.anchors;

--- a/src/plugin/predefined/ImagePlugin.js
+++ b/src/plugin/predefined/ImagePlugin.js
@@ -75,6 +75,10 @@ var ImagePlugin = Plugin.extend({
     if (!source) {
       return false;
     }
+    if (options.inline) {
+      source = source.replace(/\(/g, '%28');
+      source = source.replace(/\)/g, '%29');
+    }
 
     var alternativeText = element.getAttribute('alt') || '';
     var imageMap = conversion.context.imageMap;


### PR DESCRIPTION
Inline URLs in `AnchorPlugin` and `ImagePlugin` should have their parentheses escaped for better compatibility.

Reference: https://meta.stackexchange.com/questions/13501/links-to-urls-containing-parentheses